### PR TITLE
Consider missing time as error and skip trackpoint

### DIFF
--- a/lib/gpx_utils/track_importer.rb
+++ b/lib/gpx_utils/track_importer.rb
@@ -12,13 +12,14 @@ module GpxUtils
     end
 
     attr_reader :coords
+    attr_reader :error_count
 
     def add_file(path)
       f = File.new(path)
       doc = Nokogiri::XML(f)
       doc.remove_namespaces!
       a = Array.new
-      error_count = 0
+      @error_count = 0
 
       trackpoints = doc.xpath('//gpx/trk/trkseg/trkpt')
       trackpoints.each do |wpt|
@@ -32,7 +33,7 @@ module GpxUtils
         if self.class.coord_valid?(w[:lat], w[:lon], w[:alt], w[:time])
           a << w
         else
-          error_count += 1
+          @error_count += 1
         end
 
       end
@@ -45,7 +46,7 @@ module GpxUtils
 
     # Only import valid coords
     def self.coord_valid?(lat, lon, elevation, time)
-      return true if lat and lon
+      return true if lat and lon and time
       return false
     end
 

--- a/spec/fixtures/sample.gpx
+++ b/spec/fixtures/sample.gpx
@@ -18,6 +18,7 @@
       </gpxx:TrackExtension>
     </extensions>
     <trkseg>
+      <trkpt lat="53.852123" lon="27.519203"><ele>235.000000</ele><hdop>7.2</hdop><sat>4</sat><fix>3d</fix></trkpt>
       <trkpt lat="52.4600566830" lon="16.9067105837">
         <ele>70.79</ele>
         <time>2012-03-24T15:54:56Z</time>

--- a/spec/gpx_utils/track_importer_spec.rb
+++ b/spec/gpx_utils/track_importer_spec.rb
@@ -13,5 +13,6 @@ describe GpxUtils::TrackImporter do
       coord[:lat].should_not == 0.0
       coord[:lon].should_not == 0.0
     end
+    g.error_count.should == 1
   end
 end


### PR DESCRIPTION
Some software (navitel.ru) might generate GPX tracks where not every
trackpoint contains time. The importer relying on time when sorting, so
it is implicitly mandatory, and coordinates should not be considered as
valid.
